### PR TITLE
Corrected selection count on 3D ranges.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,8 +53,8 @@ function getNumberOfSelectedLines(
   let lines = 0;
   if (editor) {
     lines = editor.selections.reduce(
-      (prev, curr) => prev + (curr.end.line - curr.start.line),
-      1
+      (prev, curr) => prev + (curr.end.line - curr.start.line) + 1,
+      0
     );
   }
   return lines;


### PR DESCRIPTION
Corrected selection count on 3D ranges. The seed should be zero for an additive reduce.